### PR TITLE
Mejoras en precisión y GUI de MidiLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ pip install .
 
 Esto instalará todas las dependencias y habilitará el comando `midiline`.
 
+Consulta `docs/install_mac.md` para ver un ejemplo de instalación en macOS.
+
 ## Uso
 
 El comando principal es `record`, que abre un puerto MIDI virtual y comienza a

--- a/docs/install_mac.md
+++ b/docs/install_mac.md
@@ -1,0 +1,28 @@
+# Instalación en macOS Catalina
+
+Estas instrucciones asumen que tienes **Homebrew** instalado. Si no es así, instálalo desde https://brew.sh.
+
+1. Instala las dependencias del sistema:
+   ```bash
+   brew install portaudio
+   ```
+2. Crea un entorno virtual de Python (3.10 o superior):
+   ```bash
+   python3 -m venv midiline-env
+   source midiline-env/bin/activate
+   pip install --upgrade pip
+   ```
+3. Instala MidiLine dentro del entorno:
+   ```bash
+   pip install -r requirements.txt  # o simplemente `pip install .`
+   ```
+
+Para ejecutar la aplicación desde la terminal:
+```bash
+midiline record --input-device 1
+```
+O para abrir la interfaz gráfica:
+```bash
+python -m midiline.gui
+```
+

--- a/src/midiline/cli.py
+++ b/src/midiline/cli.py
@@ -17,7 +17,8 @@ def cli():
               help='Umbral de amplitud para detectar notas')
 @click.option('--tolerance', default=0.8, type=float,
               help='Tolerancia de detección de tono (aubio)')
-def record(input_device, buffer_size, midi_port, amp_threshold, tolerance):
+@click.option('--debug', is_flag=True, help='Imprime información de depuración')
+def record(input_device, buffer_size, midi_port, amp_threshold, tolerance, debug):
     """Captura audio y envía notas MIDI en tiempo real."""
     samplerate = 44100
     pitch_o = aubio.pitch('yin', buffer_size * 2, buffer_size, samplerate)
@@ -38,6 +39,8 @@ def record(input_device, buffer_size, midi_port, amp_threshold, tolerance):
         amplitude = float(np.sqrt(np.mean(samples ** 2)))
         pitch = pitch_o(samples)[0]
         confidence = pitch_o.get_confidence()
+        if debug:
+            print(f"amp={amplitude:.4f} pitch={pitch:.2f} conf={confidence:.2f}")
         if (
             pitch > 0
             and amplitude > amp_threshold


### PR DESCRIPTION
## Summary
- add install guide for Mac Catalina
- show link to guide in README
- simplify GUI with dropdowns and units
- add debug option to CLI and realtime processing
- require stable pitch before triggering note on

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768fa19c888333a23e1cea9b7c4da5