### PR TITLE
Fix GUI silence control and package import

### DIFF
--- a/src/midiline/gui.py
+++ b/src/midiline/gui.py
@@ -73,6 +73,7 @@ class RecorderThread(threading.Thread):
             gate_threshold=self.gate_threshold,
             gate_attack=self.gate_attack,
             gate_release=self.gate_release,
+            silence=self.silence,
             debug=self.debug,
         )
 

--- a/src/midiline/midi_output.py
+++ b/src/midiline/midi_output.py
@@ -2,7 +2,7 @@ from typing import Iterable
 import time
 import mido
 
-from events import NoteEvent
+from .events import NoteEvent
 
 class MidiOutput:
     """Send NoteOn/NoteOff messages to a MIDI output port."""

--- a/src/midiline/realtime.py
+++ b/src/midiline/realtime.py
@@ -43,11 +43,12 @@ class RealTimeProcessor:
         gate_attack: int = 2,
         gate_release: int = 10,
         onset_frames: int = 2,
+        silence: float = -40.0,
         debug: bool = False,
     ) -> None:
         self.pitch_o = aubio.pitch("yin", buffer_size * 2, buffer_size, samplerate)
         self.pitch_o.set_unit("midi")
-        self.pitch_o.set_silence(-40)
+        self.pitch_o.set_silence(silence)
         self.pitch_o.set_tolerance(tolerance)
         self.pitch_tolerance = float(tolerance)
 


### PR DESCRIPTION
## Summary
- connect GUI "Silencio" slider with `RealTimeProcessor`
- use package-relative import for `MidiOutput`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769b5288d88333990fc459f74a7c83