### PR TITLE
Update GUI recording behavior and improve low note detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Desde ella puedes seleccionar el dispositivo de entrada y ajustar parámetros
 de forma avanzada. La ventana incluye diales para el tamaño de buffer,
 la frecuencia de corte del filtro paso alto, la velocidad y el canal MIDI,
 así como controles para la tasa de muestreo, tamaño de frame y
-umbral de silencio.
+umbral de silencio. La captura de audio comienza automáticamente al abrir la
+aplicación y se detiene al cerrar la ventana.
 
 ## Pruebas
 

--- a/src/midiline/realtime.py
+++ b/src/midiline/realtime.py
@@ -34,7 +34,7 @@ class RealTimeProcessor:
         samplerate: int = 44100,
         tolerance: float = 0.8,
         amp_threshold: float = 0.01,
-        history_size: int = 5,
+        history_size: int = 3,
         release_frames: int = 5,
         cutoff: float | None = None,
         velocity: int = 64,
@@ -49,7 +49,8 @@ class RealTimeProcessor:
         self.pitch_o.set_unit("Hz")
         self.pitch_o.set_silence(silence)
         self.pitch_o.set_tolerance(tolerance)
-        self.min_freq = 40.0
+        # Detect pitches down to roughly D2 (~73 Hz)
+        self.min_freq = 60.0
         self.max_freq = 10000.0
         self.pitch_tolerance = float(tolerance)
 


### PR DESCRIPTION
## Summary
- auto-start recording when the GUI launches
- drop the start/stop button from the interface
- allow high-pass cutoff down to 60 Hz and detect pitches down to D2
- reduce history window for quicker response
- document the new automatic recording behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876acc9f0e48333b0f47773369ec258